### PR TITLE
Keep all IDs as strings

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,14 +35,8 @@ export function initializeContext (context, request) {
     inflection.singularize(uriObject.type) : uriObject.type : null
 
   context.request.ids = uriObject.ids ?
-    (Array.isArray(uriObject.ids) ?
-    uriObject.ids : [ uriObject.ids ])
-    .map(id => {
-      // Stolen from jQuery source code:
-      // https://api.jquery.com/jQuery.isNumeric/
-      const float = Number.parseFloat(id)
-      return id - float + 1 >= 0 ? float : id
-    }) : null
+    Array.isArray(uriObject.ids) ?
+    uriObject.ids : [ uriObject.ids ] : null
 
   const { type, ids } = context.request
   const fields = recordTypes[type]


### PR DESCRIPTION
This change hasn't addressed the test issues it will cause, as I wanted to discuss it with you before I put that work in. The reason we need this change is as follows: when we create an object using fortune, it gets sent back to ember with a string ID. Then, when we do an update on that same object, the update fails because the string ID in the post body doesn't match the parsed numeric ID from the URL. It can be fixed this way, which is a breaking change and involves quite a few test changes. Or we could change the comparison code in the update code to do == instead of === which seems a little sketchy. Please let me know what you think. The JSON-API spec says all IDs should be strings
