### PR TITLE
Filters may contain an underscore. The keyword after the underscore will be used for custom queries.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -245,7 +245,9 @@ function attachQueries (context) {
     if (parameter.match(isFilter)) {
       if (!('match' in request.options)) request.options.match = {}
       const field = (parameter.match(inBrackets) || [])[1]
-      const fieldType = fields[field][keys.type]
+      const fieldType = (fields[field] ?
+        fields[field][keys.type] :
+        fields[field.split('_')[0]][keys.type])
       const value = query[parameter]
 
       request.options.match[field] = Array.isArray(value) ?


### PR DESCRIPTION
ex: name_like
    birthDate_before
    birthDate_after
    numberOfItems_gt
    numberOfItems_lt

we can now use the keyword after the underscore for custom queries.
confer the way endpoints is doing it:

  born_before: function (qb, value) {
     return qb.where('date_of_birth', '<', value);
   },
   born_after: function (qb, value) {
     return qb.where('date_of_birth', '>', value);
   }
