### PR TITLE
fix Accept header handling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,14 +10,18 @@ export function initializeContext (context, request) {
     errors: { NotAcceptableError, UnsupportedError, NotFoundError }
   } = this
 
-  // According to the spec, no accept parameters.
-  if (request.headers['accept'] && ~request.headers['accept'].indexOf(';'))
-    throw new NotAcceptableError(`Accept parameters are not allowed.`)
-
-  // According to the spec, no content-type parameters.
-  if (request.headers['content-type'] &&
-  ~request.headers['content-type'].indexOf(';'))
-    throw new UnsupportedError(`Media type parameters are not allowed.`)
+  // According to the spec, if the media type is provided in the Accept
+  // header, it should be included at least once without any media type
+  // parameters.
+  if (request.headers['accept'] &&
+    ~request.headers['accept'].indexOf(mediaType)) {
+    const escapedMediaType = mediaType.replace(/[\+\.]/g, '\\$&')
+    const mediaTypeRegex = new RegExp(`${escapedMediaType}(?!;)`, 'g')
+    if (!request.headers['accept'].match(mediaTypeRegex))
+      throw new NotAcceptableError(`The Accept header should contain` +
+        `at least one instance of the JSON media type without any` +
+        `media type parameters.`)
+  }
 
   const { request: { serializerInput, serializerOutput, meta } } = context
 


### PR DESCRIPTION
 This fixes #8.

The [JSON API spec](http://jsonapi.org/format/) states the following under "Server responsibilities":

> Servers **MUST** respond with a 406 Not Acceptable status code if a request's `Accept` header contains the JSON API media type and all instances of that media type are modified with media type parameters.
> 
> _Note: The content negotiation requirements exist to allow future versions of this specification to use media type parameters for extension negotiation and versioning._

My implementation first checks if an `Accept` header is present, and the `Accept` header contains at least one instance of `application/vnd.api+json`.

The spec says we need one without media type parameters, and media type parameters are always prefixed with a semicolon (as per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)). So, we use a regular expression to check if there is at least one instance of `application/vnd.api+json` not followed by a `;` character. If there is none, then we throw a `406 Not Acceptable` status code.
