### PR TITLE
Fix inflected date fields during create and update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,10 +343,11 @@ class JsonApiSerializer extends Serializer {
       if (reservedKeys.attributes in record)
         for (let field in record[reservedKeys.attributes]) {
           const value = record[reservedKeys.attributes][field]
-          const fieldDefinition = fields[field] || {}
-          const fieldType = fieldDefinition[keys.type]
 
           if (inflectKeys) field = inflection.camelize(under(field), true)
+
+          const fieldDefinition = fields[field] || {}
+          const fieldType = fieldDefinition[keys.type]
 
           clone[field] = Array.isArray(value) ?
             value.map(cast(fieldType, options)) :
@@ -430,10 +431,11 @@ class JsonApiSerializer extends Serializer {
       if (reservedKeys.attributes in update)
         for (let field in update[reservedKeys.attributes]) {
           const value = update[reservedKeys.attributes][field]
-          const fieldDefinition = fields[field] || {}
-          const fieldType = fieldDefinition[keys.type]
 
           if (inflectKeys) field = inflection.camelize(under(field), true)
+
+          const fieldDefinition = fields[field] || {}
+          const fieldType = fieldDefinition[keys.type]
 
           replace[field] = Array.isArray(value) ?
             value.map(cast(fieldType, options)) :

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,8 @@ run(() => {
           birthday: new Date().toJSON(),
           picture: new Buffer('This is a string.').toString('base64'),
           'favorite-food': 'Bacon',
-          nicknames: [ 'Doge', 'The Dog' ]
+          nicknames: [ 'Doge', 'The Dog' ],
+          'some-date': '2015-01-04T00:00:00.000Z'
         },
         relationships: {
           owner: {
@@ -58,6 +59,8 @@ run(() => {
       .toString() === 'This is a string.', 'buffer is correct')
     ok(Date.now() - new Date(response.body.data.attributes.birthday)
       .getTime() < 60 * 1000, 'date is close enough')
+    ok(response.body.data.attributes['some-date'] ===
+       '2015-01-04T00:00:00.000Z', 'inflected casted value is correct')
   })
 })
 
@@ -118,7 +121,8 @@ run(() => {
         type: 'users',
         attributes: {
           name: 'Jenny Death',
-          'camel-case-field': 'foobar'
+          'camel-case-field': 'foobar',
+          'some-date': '2015-01-07'
         },
         relationships: {
           spouse: {
@@ -147,6 +151,8 @@ run(() => {
     ok(response.status === 200, 'status is correct')
     ok(Math.abs(new Date(response.body.data.attributes['last-modified'])
       .getTime() - Date.now()) < 5 * 1000, 'update modifier is correct')
+    ok(response.body.data.attributes['some-date'] ===
+       '2015-01-07T00:00:00.000Z', 'inflected casted value is correct')
   })
 })
 


### PR DESCRIPTION
This fixes an issue where camel cased fields weren't getting casted correctly. The existing tests happen to test camel cased string fields which just ends up working out down the line but Dates and, I think, custom casts would fail.

Added test data to fortune in https://github.com/fortunejs/fortune/pull/168

I wasn't too sure if this breaks any code style rules you have by pushing the variable declarations below the inflection work. Let me know if you prefer something else.
