### PR TITLE
prevent POST request crash when type is missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -384,6 +384,9 @@ class JsonApiSerializer extends Serializer {
     data = [ data ]
 
     return data.map(record => {
+      if (!(reservedKeys.type in record))
+        throw new BadRequestError('The required field "type" is missing.')
+
       const clone = {}
       const recordType = inflectType ?
         inflection.singularize(record[reservedKeys.type]) :


### PR DESCRIPTION
otherwise throws 'cannot call toLowerCase() on undefined' to user
