### PR TITLE
Fix index route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const checkLowerCase = helpers.checkLowerCase
 // complication. From a web architecture standpoint, it assumes tight coupling
 // with the API consumer and the HTTP protocol. For example, it assumes that
 // the client has *a priori* knowledge of types that exist on the server, since
-// it does not define an entry point.
+// links are optional.
 //
 // The format may seem reasonable but contains so many edge cases to not only
 // be fully spec compliant, but also following the recommendations and other

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,6 +138,7 @@ module.exports = Serializer => {
 
       contextResponse.payload = {
         [reservedKeys.jsonapi]: jsonapi,
+        [reservedKeys.meta]: {},
         [reservedKeys.links]: {}
       }
 


### PR DESCRIPTION
In #45 , there are 13 failing tests. This fixes 2 of them. 11 to go!

---

I separated out the code changes from the comment changes. Feel free to drop the comment changes / make adjustments as you see fit, @daliwali . I based the changes on our conversation over in #43 

Also, I originally thought the string links were making the responses invalid, but I was wrong! String links are valid. It was the absence of one of: `data`, `errors`, or `meta` that was invalid. My mistake.

---

Resolves #43 