### PR TITLE
Add more granular type inflection controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ server.listen(8080)
 The `options` object is as follows:
 
 - `prefix`: hyperlink prefix, without leading or trailing slashes. Default: `""` (empty string).
-- `inflectType`: pluralize and dasherize the record type name in the URI. Default: `true`.
+- `inflectType`: pluralize and dasherize the record type name in the URI. Can be Boolean to enable/disable all inflections or an object specifying each type in specific with unreferenced types set to default, ex: `{ faculty: false }`. Default: `true`.
 - `inflectKeys`: camelize the field names per record. Default: `true`.
 - `maxLimit`: maximum number of records to show per page. Default: `1000`.
 - `includeLimit`: maximum depth of fields per include. Default: `3`.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,11 +12,12 @@ const isFilter = settings.isFilter
 const mediaType = settings.mediaType
 const pageOffset = settings.pageOffset
 const pageLimit = settings.pageLimit
+const inflectTypeDef = settings.defaults.inflectType
 
 
 module.exports = {
   initializeContext, mapRecord, mapId, matchId, castId,
-  underscore, parseBuffer, checkLowerCase
+  underscore, parseBuffer, checkLowerCase, setInflectType
 }
 
 
@@ -70,9 +71,11 @@ function initializeContext (contextRequest, request, response) {
     throw new NotFoundError('Invalid URI.')
 
   const type = contextRequest.type = request.meta.type =
-    uriObject.type ? inflectType ? checkLowerCase(inflection.transform(
-      underscore(uriObject.type), typeInflections[0]), recordTypes) :
-      uriObject.type : null
+    uriObject.type ? inflectType[uriObject.type] ?
+      checkLowerCase(
+        inflection.transform(underscore(uriObject.type), typeInflections[0]),
+        recordTypes
+      ) : uriObject.type : null
 
   // Show allow options.
   if (request.method === 'OPTIONS' && (!type || type in recordTypes)) {
@@ -181,7 +184,7 @@ function mapRecord (type, record) {
 
   const id = record[keys.primary]
 
-  clone[reservedKeys.type] = inflectType ?
+  clone[reservedKeys.type] = inflectType[type] ?
     inflection.transform(type, typeInflections[1]) : type
   clone[reservedKeys.id] = id.toString()
   clone[reservedKeys.meta] = {}
@@ -189,7 +192,7 @@ function mapRecord (type, record) {
   clone[reservedKeys.relationships] = {}
   clone[reservedKeys.links] = {
     [reservedKeys.self]: prefix + uriTemplate.fillFromObject({
-      type: inflectType ?
+      type: inflectType[type] ?
         inflection.transform(type, typeInflections[1]) : type,
       ids: id
     })
@@ -227,14 +230,14 @@ function mapRecord (type, record) {
     // Handle link fields.
     const ids = record[originalField]
 
-    const linkedType = inflectType ?
+    const linkedType = inflectType[fieldDefinition[keys.link]] ?
       inflection.transform(fieldDefinition[keys.link], typeInflections[1]) :
       fieldDefinition[keys.link]
 
     clone[reservedKeys.relationships][field] = {
       [reservedKeys.links]: {
         [reservedKeys.self]: prefix + uriTemplate.fillFromObject({
-          type: inflectType ?
+          type: inflectType[type] ?
             inflection.transform(type, typeInflections[1]) : type,
           ids: id,
           relatedField: reservedKeys.relationships,
@@ -242,7 +245,7 @@ function mapRecord (type, record) {
             [ 'underscore', 'dasherize' ]) : field
         }),
         [reservedKeys.related]: prefix + uriTemplate.fillFromObject({
-          type: inflectType ?
+          type: inflectType[type] ?
             inflection.transform(type, typeInflections[1]) : type,
           ids: id,
           relatedField: inflectKeys ? inflection.transform(field,
@@ -310,7 +313,7 @@ function attachQueries (request) {
       const fields = sparseField.reduce(reduceFields, {})
       let sparseType = (parameter.match(inBrackets) || [])[1]
 
-      if (inflectType)
+      if (inflectType[type])
         sparseType = checkLowerCase(
           inflection.transform(sparseType, typeInflections[0]),
           recordTypes
@@ -481,4 +484,32 @@ function bool (value) {
   if (typeof value === 'boolean') return value
 
   return false
+}
+
+/**
+ * Generate a list of which types are inflected.
+ * @param {Boolean|Object} inflect setting from defaults or user override
+ * @param {String[]} types array of declared types
+ * @return {Object}
+ */
+function setInflectType (inflect, types) {
+  // use inflections if set as object else start fresh
+  const out = typeof inflect === 'boolean' ? {} : inflect
+
+  // if inflect is boolean use it for all types,
+  // else use default for unset types
+  const setInflect = typeof inflect === 'boolean' ? inflect : inflectTypeDef
+
+  // For each Type set inflection, if not set
+  for (const t of types) {
+    const plural = inflection.transform(t, typeInflections[1])
+    if (!(t in out))
+      out[t] = setInflect
+
+    // allow checking on pluralized too
+    if (!(plural in out))
+      out[plural] = out[t]
+  }
+
+  return out
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ const initializeContext = helpers.initializeContext
 const underscore = helpers.underscore
 const parseBuffer = helpers.parseBuffer
 const checkLowerCase = helpers.checkLowerCase
+const setInflectType = helpers.setInflectType
 
 
 // JSON API is a compromise. There are many incidental complexities involved
@@ -67,6 +68,12 @@ module.exports = Serializer => {
       for (const key in defaults)
         if (!(key in options))
           options[key] = defaults[key]
+
+      // Convert type inflection check to object
+      options.inflectType = setInflectType(
+        options.inflectType,
+        Object.getOwnPropertyNames(this.recordTypes)
+      )
 
       // Automatically prefix leading slash.
       if (options.prefix && options.prefix.charAt(0) !== '/')
@@ -142,7 +149,8 @@ module.exports = Serializer => {
       }
 
       for (let type in recordTypes) {
-        if (inflectType) type = inflection.transform(type, typeInflections[1])
+        if (inflectType[type]) type =
+          inflection.transform(type, typeInflections[1])
         contextResponse.payload[reservedKeys.links][type] = prefix +
           uriTemplate.fillFromObject({ type })
       }
@@ -195,7 +203,7 @@ module.exports = Serializer => {
         const offset = meta.options.offset
         const collection = prefix + uriTemplate.fillFromObject({
           query,
-          type: inflectType ?
+          type: inflectType[type] ?
             inflection.transform(type, typeInflections[1]) : type
         })
 
@@ -216,7 +224,7 @@ module.exports = Serializer => {
 
           const paged = prefix + uriTemplate.fillFromObject({
             query,
-            type: inflectType ?
+            type: inflectType[type] ?
               inflection.transform(type, typeInflections[1]) : type
           })
 
@@ -245,7 +253,7 @@ module.exports = Serializer => {
         if (ids)
           output[reservedKeys.links] = {
             [reservedKeys.self]: prefix + uriTemplate.fillFromObject({
-              type: inflectType ?
+              type: inflectType[type] ?
                 inflection.transform(type, typeInflections[1]) : type,
               ids
             })
@@ -263,7 +271,7 @@ module.exports = Serializer => {
         if (method === methods.create)
           contextResponse.meta.headers['Location'] = prefix +
             uriTemplate.fillFromObject({
-              type: inflectType ?
+              type: inflectType[type] ?
                 inflection.transform(type, typeInflections[1]) : type,
               ids: records.map(record => record[keys.primary])
             })
@@ -276,7 +284,7 @@ module.exports = Serializer => {
       if (relatedField)
         output[reservedKeys.links] = {
           [reservedKeys.self]: prefix + uriTemplate.fillFromObject({
-            type: inflectType ?
+            type: inflectType[originalType] ?
               inflection.transform(originalType, typeInflections[1]) :
               originalType,
             ids: originalIds,
@@ -331,7 +339,7 @@ module.exports = Serializer => {
         [reservedKeys.jsonapi]: jsonapi,
         [reservedKeys.links]: {
           [reservedKeys.self]: prefix + uriTemplate.fillFromObject({
-            type: inflectType ?
+            type: inflectType[originalType] ?
               inflection.transform(originalType, typeInflections[1]) :
               originalType,
             ids: originalIds, relatedField: reservedKeys.relationships,
@@ -339,7 +347,7 @@ module.exports = Serializer => {
                 [ 'underscore', 'dasherize' ]) : relatedField
           }),
           [reservedKeys.related]: prefix + uriTemplate.fillFromObject({
-            type: inflectType ?
+            type: inflectType[originalType] ?
               inflection.transform(originalType, typeInflections[1]) :
               originalType,
             ids: originalIds,
@@ -351,7 +359,7 @@ module.exports = Serializer => {
 
       const isArray = recordTypes[originalType][relatedField][keys.isArray]
       const identifiers = records.map(record => ({
-        [reservedKeys.type]: inflectType ?
+        [reservedKeys.type]: inflectType[type] ?
           inflection.transform(type, typeInflections[1]) : type,
         [reservedKeys.id]: record[keys.primary].toString()
       }))
@@ -417,7 +425,7 @@ module.exports = Serializer => {
             `The required field "${reservedKeys.type}" is missing.`)
 
         const clone = {}
-        const recordType = inflectType ?
+        const recordType = inflectType[record[reservedKeys.type]] ?
           checkLowerCase(inflection.transform(
             underscore(record[reservedKeys.type]),
             typeInflections[0]), recordTypes) :
@@ -455,9 +463,10 @@ module.exports = Serializer => {
               throw new BadRequestError('The ' +
                 `"${reservedKeys.primary}" field is missing.`)
 
-            const relatedType = inflectType ? inflection.transform(
-              fields[field][keys.link], typeInflections[1]) :
-              fields[field][keys.link]
+            const linkKey = fields[field][keys.link]
+            const relatedType = inflectType[linkKey] ? inflection.transform(
+              linkKey, typeInflections[1]) :
+              linkKey
             const relatedIsArray = fields[field][keys.isArray]
             const data = value[reservedKeys.primary]
 
@@ -516,7 +525,7 @@ module.exports = Serializer => {
 
       for (const update of data) {
         const replace = {}
-        const updateType = inflectType ?
+        const updateType = inflectType[update[reservedKeys.type]] ?
           checkLowerCase(inflection.transform(
             underscore(update[reservedKeys.type]),
             typeInflections[0]), recordTypes) :
@@ -554,7 +563,7 @@ module.exports = Serializer => {
               throw new BadRequestError(
                 `The "${reservedKeys.primary}" field is missing.`)
 
-            const relatedType = inflectType ?
+            const relatedType = inflectType[fields[field][keys.link]] ?
               inflection.transform(fields[field][keys.link],
                 typeInflections[1]) : fields[field][keys.link]
             const relatedIsArray = fields[field][keys.isArray]
@@ -618,7 +627,7 @@ module.exports = Serializer => {
         else throw new BadRequestError('Data must be singular.')
 
       updateIds = updateIds.map(update => {
-        const updateType = inflectType ?
+        const updateType = inflectType[update[reservedKeys.type]] ?
           checkLowerCase(inflection.transform(
             underscore(update[reservedKeys.type]),
             typeInflections[0]), recordTypes) :


### PR DESCRIPTION
I made sure all original tests pass and added some other tests (though unsure if you will like the format) to the end which will fail without `inflectType: { animal: false }` in the serializer options. 

I'm happy to make changes if you don't like some of it or how I implemented.