### PR TITLE
Allow for null values to be patch to singular resource relationships

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -607,6 +607,15 @@ module.exports = Serializer => {
       const originalIds = contextRequest.originalIds
 
       const isArray = recordTypes[originalType][relatedField][keys.isArray]
+      const isNull = !isArray && payload[reservedKeys.primary] === null
+
+      if (isNull)
+        return [{
+          id: originalIds[0],
+          replace: {
+            [relatedField]: null
+          }
+        }]
 
       if (originalIds.length > 1)
         throw new NotFoundError(

--- a/test/index.js
+++ b/test/index.js
@@ -500,6 +500,20 @@ run((assert, comment) => {
 
 
 run((assert, comment) => {
+  comment('update a singular relationship entity with null')
+  return test('/users/2/relationships/spouse', {
+    method: 'patch',
+    headers: { 'Content-Type': mediaType },
+    body: {
+      data: null
+    }
+  }, response => {
+    assert(response.status === 204, 'status is correct')
+  })
+})
+
+
+run((assert, comment) => {
   comment('update an array relationship entity')
   return test('/users/1/relationships/owned-pets', {
     method: 'patch',


### PR DESCRIPTION
Another minor fix. Per the JSON API spec:

```
PATCH /articles/1/relationships/author HTTP/1.1
Content-Type: application/vnd.api+json
Accept: application/vnd.api+json

{
  "data": null
}
```

That should delete the author relationship on article 1. This PR lets this code base support that feature.