### PR TITLE
add in forgotten context mutation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -609,13 +609,18 @@ module.exports = Serializer => {
       const isArray = recordTypes[originalType][relatedField][keys.isArray]
       const isNull = !isArray && payload[reservedKeys.primary] === null
 
-      if (isNull)
+      if (isNull) {
+        // Rewrite type and IDs.
+        contextRequest.type = originalType
+        contextRequest.ids = null
+
         return [{
           id: originalIds[0],
           replace: {
             [relatedField]: null
           }
         }]
+      }
 
       if (originalIds.length > 1)
         throw new NotFoundError(


### PR DESCRIPTION
I forgot to mutate the context on ID and type for null bodies. All my use cases are now covered as far as I can tell, so this should be it for PRs for me I hope.

Thanks for your work on fortune. This library has been quite helpful in dealing with the joy that is json:api.