### PR TITLE
Attempt to allow fuzzy-match filter in json-api

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -353,6 +353,20 @@ function attachQueries (request) {
         request.options.range[field][index] =
           castValue(query[parameter], fieldType, options)
       }
+      else if (filterType === 'fuzzy-match'){
+
+        if ( ! fields[field].type ){
+          throw new BadRequestError( `fuzzy-match only allowed on attributes.` )
+        }
+
+        if ( fields[field].type.name !== "String"){
+          throw new BadRequestError(
+            `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
+        }
+
+        if (!('fuzzyMatch' in request.options)) request.options['fuzzyMatch'] = {}
+        request.options.fuzzyMatch[field] = query[parameter]
+      }
       else throw new BadRequestError(
         `The filter "${filterType}" is not valid.`)
     }


### PR DESCRIPTION
Hello, 

with regard to #60, I started implementing, or rather, looking for ways to implement extensions on the current filtering possibilities.

### Some notes

#### General

Here, I wanted fuzzy text search on a String attribute.  I validated this against the fortune-postgres, which needed to be extened too. 
You may find the relevant commit here: https://github.com/cecemel/fortune-postgres/commit/e80461544faf7ca7e8f46ff9a60cf6fa1f75a1e9. I didn't start a PR for this one yet.   I just want first to make sure we agree on interface and how the query is passed down through all layers.
So I consider this PR a base for discussion. 
#### Regarding integration into fortune.js

I am unsure what field of `request.options` may be used. The fortune-postgres seemed to already use the `query` field, of which at first sight seemed to be the wanted escape hatch, so I didn't feel like using this.

So, as I understand it, [`Adapter.find`](http://fortune.js.org/api/#adapter-find) leaves the possibility of extra fields on the options object unspecified. Therefore, I added `fuzzyMatch` on the options object.

#### Regarding validity JSON:API

Filtering is relatively unspecified. As such, I assume the extra filter
type is legal.