### PR TITLE
Feature/wip filtering relationship

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -333,17 +333,25 @@ function attachQueries (request) {
       if (isRelationFilter(field)) {
         const relationPath = field
         if (filterType !== 'fuzzy-match')
-          throw new BadRequestError('Filtering relationship only supported on fuzzy-match for now')
+          throw new BadRequestError(
+            `Filtering relationship only
+            supported on fuzzy-match for now
+          `)
 
-        console.log('Checking path')
-        if (! isValidRelationPath( recordTypes, fields, getRelationFilterSegments(field) ) )
+        const isValidPath =
+              isValidRelationPath( recordTypes,
+                                   fields,
+                                   getRelationFilterSegments(field) )
+        if (! isValidPath )
           throw new BadRequestError(`Path ${relationPath} is not valid`)
       }
 
       else if (!(field in fields))
         throw new BadRequestError(`The field "${field}" is non-existent.`)
 
-      const fieldType = getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type]
+      const filterSegments = getRelationFilterSegments(field)
+      const fieldType = getLastTypeInPath( recordTypes,
+                                           fields, filterSegments )[keys.type]
 
       if (filterType === void 0) {
         if (!('match' in request.options)) request.options.match = {}
@@ -365,16 +373,24 @@ function attachQueries (request) {
           castValue(query[parameter], fieldType, options)
       }
       else if (filterType === 'fuzzy-match') {
-        if ( ! getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type] )
-          throw new BadRequestError( `fuzzy-match only allowed on attributes. For ${field}` )
-
-
-        if ( getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type].name !== 'String')
+        const lastTypeInPath =
+              getLastTypeInPath( recordTypes,
+                                 fields,
+                                 getRelationFilterSegments(field) )
+        if ( ! lastTypeInPath[keys.type] )
           throw new BadRequestError(
-            `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
+            `fuzzy-match only allowed on attributes. For ${field}` )
 
 
-        if (!('fuzzyMatch' in request.options)) request.options['fuzzyMatch'] = {}
+        if ( lastTypeInPath[keys.type].name !== 'String')
+          throw new BadRequestError(
+            `fuzzy-match only allowed on String types.
+             ${field} is of type ${fields[field].type.name }
+          ` )
+
+
+        if (!('fuzzyMatch' in request.options))
+          request.options['fuzzyMatch'] = {}
         request.options.fuzzyMatch[field] = query[parameter]
       }
       else throw new BadRequestError(
@@ -540,7 +556,9 @@ function setInflectType (inflect, types) {
   return out
 }
 
-function isValidRelationPath ( recordTypes, fieldsCurrentType, remainingPathSegments ) {
+function isValidRelationPath ( recordTypes,
+                               fieldsCurrentType,
+                               remainingPathSegments ) {
   if ( !remainingPathSegments.length )
     return false
 
@@ -549,18 +567,23 @@ function isValidRelationPath ( recordTypes, fieldsCurrentType, remainingPathSegm
   if ( !fieldsCurrentType[pathSegment] )
     return false
 
-  if ( fieldsCurrentType[pathSegment].type && remainingPathSegments.length == 1 )
+  if ( fieldsCurrentType[pathSegment].type
+       && remainingPathSegments.length === 1 )
     return true
 
 
   const nextTypeToCompare = fieldsCurrentType[pathSegment].link
   if ( nextTypeToCompare )
-    return isValidRelationPath( recordTypes, recordTypes[nextTypeToCompare], remainingPathSegments.slice(1) )
+    return isValidRelationPath( recordTypes,
+                                recordTypes[nextTypeToCompare],
+                                remainingPathSegments.slice(1) )
 
   return false
 }
 
-function getLastTypeInPath ( recordTypes, fieldsCurrentType, remainingPathSegments ) {
+function getLastTypeInPath ( recordTypes,
+                             fieldsCurrentType,
+                             remainingPathSegments ) {
   if ( !remainingPathSegments.length )
     return fieldsCurrentType
 
@@ -573,7 +596,9 @@ function getLastTypeInPath ( recordTypes, fieldsCurrentType, remainingPathSegmen
 
   const nextType = fieldsCurrentType[pathSegment].link
   if ( nextType )
-    return getLastTypeInPath( recordTypes, recordTypes[nextType], remainingPathSegments.slice(1) )
+    return getLastTypeInPath( recordTypes,
+                              recordTypes[nextType],
+                              remainingPathSegments.slice(1) )
 
   return fieldsCurrentType[pathSegment]
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -385,7 +385,7 @@ function attachQueries (request) {
         if ( lastTypeInPath[keys.type].name !== 'String')
           throw new BadRequestError(
             `fuzzy-match only allowed on String types.
-             ${field} is of type ${fields[field].type.name }
+             ${field} is of type ${lastTypeInPath[keys.type].name}
           ` )
 
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -329,10 +329,21 @@ function attachQueries (request) {
       const field = inflect(matches[1])
       const filterType = matches[2]
 
-      if (!(field in fields)) throw new BadRequestError(
-        `The field "${field}" is non-existent.`)
+      if(field.split('.').length > 1){
+        const relationPath = field;
+        if(filterType !== 'fuzzy-match'){
+          throw new BadRequestError('Filtering relationship only supported on fuzzy-match for now')
+        }
+        console.log('Checking path')
+        if(! isValidRelationPath( recordTypes, fields, field.split('.')) ){
+          throw new BadRequestError(`Path ${relationPath} is not valid`)
+        }
+      }
 
-      const fieldType = fields[field][keys.type]
+      else if (!(field in fields))
+        throw new BadRequestError(`The field "${field}" is non-existent.`)
+
+      const fieldType = getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type]
 
       if (filterType === void 0) {
         if (!('match' in request.options)) request.options.match = {}
@@ -355,11 +366,11 @@ function attachQueries (request) {
       }
       else if (filterType === 'fuzzy-match'){
 
-        if ( ! fields[field].type ){
-          throw new BadRequestError( `fuzzy-match only allowed on attributes.` )
+        if ( ! getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type] ){
+          throw new BadRequestError( `fuzzy-match only allowed on attributes. For ${field}` )
         }
 
-        if ( fields[field].type.name !== "String"){
+        if ( getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type].name !== "String"){
           throw new BadRequestError(
             `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
         }
@@ -528,4 +539,43 @@ function setInflectType (inflect, types) {
   }
 
   return out
+}
+
+
+function isValidRelationPath( recordTypes, fieldsCurrentType, remainingPathSegments ){
+  if( !remainingPathSegments.length ){
+    return false
+  }
+  const pathSegment = remainingPathSegments[0]
+
+  if( !fieldsCurrentType[pathSegment] ){
+    return false
+  }
+  if( fieldsCurrentType[pathSegment].type && remainingPathSegments.length == 1 ){
+    return true
+  }
+
+  const nextTypeToCompare = fieldsCurrentType[pathSegment].link
+  if( nextTypeToCompare ){
+    return isValidRelationPath( recordTypes, recordTypes[nextTypeToCompare], remainingPathSegments.slice(1) )
+  }
+  return false
+}
+
+function getLastTypeInPath( recordTypes, fieldsCurrentType, remainingPathSegments ){
+  if( !remainingPathSegments.length ){
+    return fieldsCurrentType
+  }
+
+  const pathSegment = remainingPathSegments[0]
+
+  if( !fieldsCurrentType[pathSegment] ){
+    return {}
+  }
+
+  const nextType = fieldsCurrentType[pathSegment].link
+  if( nextType ){
+    return getLastTypeInPath( recordTypes, recordTypes[nextType], remainingPathSegments.slice(1) )
+  }
+  return fieldsCurrentType[pathSegment]
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -329,13 +329,13 @@ function attachQueries (request) {
       const field = inflect(matches[1])
       const filterType = matches[2]
 
-      if(field.split('.').length > 1){
+      if(isRelationFilter(field)){
         const relationPath = field;
         if(filterType !== 'fuzzy-match'){
           throw new BadRequestError('Filtering relationship only supported on fuzzy-match for now')
         }
         console.log('Checking path')
-        if(! isValidRelationPath( recordTypes, fields, field.split('.')) ){
+        if(! isValidRelationPath( recordTypes, fields, getRelationFilterSegments(field) ) ){
           throw new BadRequestError(`Path ${relationPath} is not valid`)
         }
       }
@@ -343,7 +343,7 @@ function attachQueries (request) {
       else if (!(field in fields))
         throw new BadRequestError(`The field "${field}" is non-existent.`)
 
-      const fieldType = getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type]
+      const fieldType = getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type]
 
       if (filterType === void 0) {
         if (!('match' in request.options)) request.options.match = {}
@@ -366,11 +366,11 @@ function attachQueries (request) {
       }
       else if (filterType === 'fuzzy-match'){
 
-        if ( ! getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type] ){
+        if ( ! getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type] ){
           throw new BadRequestError( `fuzzy-match only allowed on attributes. For ${field}` )
         }
 
-        if ( getLastTypeInPath( recordTypes, fields, field.split('.') )[keys.type].name !== "String"){
+        if ( getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type].name !== "String"){
           throw new BadRequestError(
             `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
         }
@@ -541,7 +541,6 @@ function setInflectType (inflect, types) {
   return out
 }
 
-
 function isValidRelationPath( recordTypes, fieldsCurrentType, remainingPathSegments ){
   if( !remainingPathSegments.length ){
     return false
@@ -578,4 +577,12 @@ function getLastTypeInPath( recordTypes, fieldsCurrentType, remainingPathSegment
     return getLastTypeInPath( recordTypes, recordTypes[nextType], remainingPathSegments.slice(1) )
   }
   return fieldsCurrentType[pathSegment]
+}
+
+function isRelationFilter( field ){
+  return field.split(':').length > 1
+}
+
+function getRelationFilterSegments( field ){
+  return field.split(':')
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -305,7 +305,7 @@ function attachQueries (request) {
   request.options = {}
 
   // Iterate over dynamic query strings.
-  for (const parameter of Object.keys(query)) {
+  for (const parameter of Object.keys(query))
     // Attach fields option.
     if (parameter.match(isField)) {
       const sparseField = Array.isArray(query[parameter]) ?
@@ -330,15 +330,14 @@ function attachQueries (request) {
       const field = inflect(matches[1])
       const filterType = matches[2]
 
-      if(isRelationFilter(field)){
-        const relationPath = field;
-        if(filterType !== 'fuzzy-match'){
+      if (isRelationFilter(field)) {
+        const relationPath = field
+        if (filterType !== 'fuzzy-match')
           throw new BadRequestError('Filtering relationship only supported on fuzzy-match for now')
-        }
+
         console.log('Checking path')
-        if(! isValidRelationPath( recordTypes, fields, getRelationFilterSegments(field) ) ){
+        if (! isValidRelationPath( recordTypes, fields, getRelationFilterSegments(field) ) )
           throw new BadRequestError(`Path ${relationPath} is not valid`)
-        }
       }
 
       else if (!(field in fields))
@@ -365,16 +364,15 @@ function attachQueries (request) {
         request.options.range[field][index] =
           castValue(query[parameter], fieldType, options)
       }
-      else if (filterType === 'fuzzy-match'){
-
-        if ( ! getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type] ){
+      else if (filterType === 'fuzzy-match') {
+        if ( ! getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type] )
           throw new BadRequestError( `fuzzy-match only allowed on attributes. For ${field}` )
-        }
 
-        if ( getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type].name !== "String"){
+
+        if ( getLastTypeInPath( recordTypes, fields, getRelationFilterSegments(field) )[keys.type].name !== 'String')
           throw new BadRequestError(
             `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
-        }
+
 
         if (!('fuzzyMatch' in request.options)) request.options['fuzzyMatch'] = {}
         request.options.fuzzyMatch[field] = query[parameter]
@@ -382,7 +380,7 @@ function attachQueries (request) {
       else throw new BadRequestError(
         `The filter "${filterType}" is not valid.`)
     }
-  }
+
 
   // Attach include option.
   if (reservedKeys.include in query) {
@@ -542,48 +540,48 @@ function setInflectType (inflect, types) {
   return out
 }
 
-function isValidRelationPath( recordTypes, fieldsCurrentType, remainingPathSegments ){
-  if( !remainingPathSegments.length ){
+function isValidRelationPath ( recordTypes, fieldsCurrentType, remainingPathSegments ) {
+  if ( !remainingPathSegments.length )
     return false
-  }
+
   const pathSegment = remainingPathSegments[0]
 
-  if( !fieldsCurrentType[pathSegment] ){
+  if ( !fieldsCurrentType[pathSegment] )
     return false
-  }
-  if( fieldsCurrentType[pathSegment].type && remainingPathSegments.length == 1 ){
+
+  if ( fieldsCurrentType[pathSegment].type && remainingPathSegments.length == 1 )
     return true
-  }
+
 
   const nextTypeToCompare = fieldsCurrentType[pathSegment].link
-  if( nextTypeToCompare ){
+  if ( nextTypeToCompare )
     return isValidRelationPath( recordTypes, recordTypes[nextTypeToCompare], remainingPathSegments.slice(1) )
-  }
+
   return false
 }
 
-function getLastTypeInPath( recordTypes, fieldsCurrentType, remainingPathSegments ){
-  if( !remainingPathSegments.length ){
+function getLastTypeInPath ( recordTypes, fieldsCurrentType, remainingPathSegments ) {
+  if ( !remainingPathSegments.length )
     return fieldsCurrentType
-  }
+
 
   const pathSegment = remainingPathSegments[0]
 
-  if( !fieldsCurrentType[pathSegment] ){
+  if ( !fieldsCurrentType[pathSegment] )
     return {}
-  }
+
 
   const nextType = fieldsCurrentType[pathSegment].link
-  if( nextType ){
+  if ( nextType )
     return getLastTypeInPath( recordTypes, recordTypes[nextType], remainingPathSegments.slice(1) )
-  }
+
   return fieldsCurrentType[pathSegment]
 }
 
-function isRelationFilter( field ){
+function isRelationFilter ( field ) {
   return field.split(':').length > 1
 }
 
-function getRelationFilterSegments( field ){
+function getRelationFilterSegments ( field ) {
   return field.split(':')
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -353,6 +353,20 @@ function attachQueries (request) {
         request.options.range[field][index] =
           castValue(query[parameter], fieldType, options)
       }
+      else if (filterType === 'fuzzy-match'){
+
+        if ( ! fields[field].type ){
+          throw new BadRequestError( `fuzzy-match only allowed on attributes.` )
+        }
+
+        if ( fields[field].type.name !== "String"){
+          throw new BadRequestError(
+            `fuzzy-match only allowed on String types. ${field} is of type ${fields[field].type.name }` )
+        }
+
+        if (!('fuzzyMatch' in request.options)) request.options['fuzzyMatch'] = {}
+        request.options.fuzzyMatch[field] = query[parameter]
+      }
       else throw new BadRequestError(
         `The filter "${filterType}" is not valid.`)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,9 +760,8 @@
       "dev": true
     },
     "fortune": {
-      "version": "5.5.17",
-      "resolved": "https://registry.npmjs.org/fortune/-/fortune-5.5.17.tgz",
-      "integrity": "sha512-xFGDev45KLW0LCIakb3hT19WQ37tE0XxKvFSa3ZcWeUglcyhrK12xLhpG2QLR3aYCi+DpKzUcYIUJu3t7pmT1A==",
+      "version": "git+https://github.com/cecemel/fortune.git#64a6f63874b369fc2738c2f0a81e8fe8abd691fa",
+      "from": "git+https://github.com/cecemel/fortune.git#64a6f63874b369fc2738c2f0a81e8fe8abd691fa",
       "dev": true,
       "requires": {
         "error-class": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "^3.0.0",
     "eslint": "^6.8.0",
     "eslint-config-boss": "^1.0.6",
-    "fortune": "^5.5.17",
+    "fortune": "https://github.com/cecemel/fortune.git#64a6f63874b369fc2738c2f0a81e8fe8abd691fa",
     "fortune-http": "^1.2.26",
     "tapdance": "^5.1.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -333,6 +333,21 @@ run((assert, comment) => {
 })
 
 run((assert, comment) => {
+  comment(`filter fuzzy-match: Jane and John have
+          a common friend called something like "soft".`)
+  return test(`/users?${qs.stringify({
+    'filter[friends:name][fuzzy-match]': 'soft'
+  })}`, null, response => {
+    assert(validate(response.body), 'response adheres to json api')
+    assert(response.status === 200, 'status is correct')
+    assert(~response.body.links.self.indexOf('/users'), 'link is correct')
+    assert(deepEqual(
+      response.body.data.map(record => record.attributes.name).sort(),
+      [ 'Jane Doe', 'John Doe' ]), 'match is correct')
+  })
+})
+
+run((assert, comment) => {
   comment('dasherizes the camel cased fields')
   return test('/users/1', null, response => {
     assert(validate(response.body), 'response adheres to json api')


### PR DESCRIPTION
As a try-out, I extend the fuzzy matching on relationship. The rest of the filters still need implementation.

Contrary to what I proposed in fortunejs/fortune-json-api#60, I changed `filter[author.posts]` to `filter[author:posts]`. Ember.js (considered baseline use case) doesn't like parsing the former.

So a call would be
`/authors?filter[posts:title][fuzzy-match]=milk`

See also #34 and fortunejs/fortune-json-api#60 and https://github.com/fortunejs/fortune-postgres/pull/35