### PR TITLE
⬆️ upgrade ajv, migrate json schema, remove use of deprecated Buffer constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ module.exports = Serializer => {
         if (value && value.type === 'Buffer' &&
           Array.isArray(value.data) &&
           Object.keys(value).length === 2)
-          return new Buffer(value.data).toString(bufferEncoding)
+          return Buffer.from(value.data).toString(bufferEncoding)
 
         return value
       }, jsonSpaces)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortune-json-api",
   "description": "JSON API serializer for Fortune.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -20,7 +20,8 @@
     "uri-templates": "^0.2.0"
   },
   "devDependencies": {
-    "ajv": "^4.11.8",
+    "ajv": "^8",
+    "ajv-formats": "^2.1.1",
     "chalk": "^3.0.0",
     "eslint": "^6.8.0",
     "eslint-config-boss": "^1.0.6",

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,8 @@
 
 const deepEqual = require('deep-equal')
 const qs = require('querystring')
-const Ajv = require('ajv')
+const Ajv = require('ajv').default
+const addFormats = require('ajv-formats').default
 
 const run = require('tapdance')
 
@@ -11,6 +12,7 @@ const jsonApi = require('../lib')
 const jsonApiResponseSchema = require('./json-api-response-schema.json')
 
 const ajv = new Ajv({allErrors: true, v5: true})
+addFormats(ajv)
 const validate = ajv.compile(jsonApiResponseSchema)
 
 const mediaType = 'application/vnd.api+json'
@@ -80,7 +82,7 @@ run((assert, comment) => {
           name: 'Rover',
           type: 'Chihuahua',
           birthday: new Date().toJSON(),
-          picture: new Buffer('This is a string.').toString('base64'),
+          picture: Buffer.from('This is a string.').toString('base64'),
           'is-neutered': true,
           nicknames: [ 'Doge', 'The Dog' ],
           'some-date': '2015-01-04T00:00:00.000Z'
@@ -102,7 +104,7 @@ run((assert, comment) => {
     assert(response.body.data.type === 'animals', 'type is correct')
     assert(response.body.data.attributes['is-neutered'] === true,
       'inflected key value is correct')
-    assert(new Buffer(response.body.data.attributes.picture, 'base64')
+    assert(Buffer.from(response.body.data.attributes.picture, 'base64')
       .toString() === 'This is a string.', 'buffer is correct')
     assert(Date.now() - new Date(response.body.data.attributes.birthday)
       .getTime() < 60 * 1000, 'date is close enough')
@@ -655,7 +657,7 @@ run((assert, comment) => {
           name: 'Rover',
           type: 'Chihuahua',
           birthday: new Date().toJSON(),
-          picture: new Buffer('This is a string.').toString('base64'),
+          picture: Buffer.from('This is a string.').toString('base64'),
           'is-neutered': true,
           nicknames: [ 'Doge', 'The Dog' ],
           'some-date': '2015-01-04T00:00:00.000Z'
@@ -677,7 +679,7 @@ run((assert, comment) => {
     assert(response.body.data.type === 'animal', 'type is correct')
     assert(response.body.data.attributes['is-neutered'] === true,
       'inflected key value is correct')
-    assert(new Buffer(response.body.data.attributes.picture, 'base64')
+    assert(Buffer.from(response.body.data.attributes.picture, 'base64')
       .toString() === 'This is a string.', 'buffer is correct')
     assert(Date.now() - new Date(response.body.data.attributes.birthday)
       .getTime() < 60 * 1000, 'date is close enough')
@@ -778,7 +780,7 @@ run((assert, comment) => {
           name: 'Rover',
           type: 'Chihuahua',
           birthday: new Date().toJSON(),
-          picture: new Buffer('This is a string.').toString('base64'),
+          picture: Buffer.from('This is a string.').toString('base64'),
           'is-neutered': true,
           nicknames: [ 'Doge', 'The Dog' ],
           'some-date': '2015-01-04T00:00:00.000Z'

--- a/test/json-api-response-schema.json
+++ b/test/json-api-response-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "JSON API Schema",
   "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
   "oneOf": [
@@ -158,7 +158,7 @@
         "self": {
           "description": "A `self` member, whose value is a URL for the relationship itself (a \"relationship URL\"). This URL allows the client to directly manipulate the relationship. For example, it would allow a client to remove an `author` from an `article` without deleting the people resource itself.",
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         "related": {
           "$ref": "#/definitions/link"
@@ -172,7 +172,7 @@
         {
           "description": "A string containing the link's URL.",
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         {
           "type": "object",
@@ -183,7 +183,7 @@
             "href": {
               "description": "A string containing the link's URL.",
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "meta": {
               "$ref": "#/definitions/meta"
@@ -287,28 +287,28 @@
         "first": {
           "description": "The first page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "last": {
           "description": "The last page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "prev": {
           "description": "The previous page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         },
         "next": {
           "description": "The next page of data",
           "oneOf": [
-            { "type": "string", "format": "uri" },
+            { "type": "string", "format": "uri-reference" },
             { "type": "null" }
           ]
         }


### PR DESCRIPTION
- ajv needed to be upgraded due to a vulnerability
  - this required pulling in `ajv-formats`, as that is now a separate module
  - this did not explicitly require migrating to json schema draft-07 but it was safe to do so
-  `new Buffer()` is deprecated; code updated
- `uri` format expects a fully qualified URI so tests were failing.  switched to `uri-reference` format which permits both absolute and relative URIs